### PR TITLE
Knob disabling

### DIFF
--- a/web/wordpress/.gitignore
+++ b/web/wordpress/.gitignore
@@ -23,5 +23,6 @@
 # Unfortunately, the above method reintroduces other 
 # undesirable files, so we re-ignore them:
 .DS_Store
+/wp-content/themes/hoxton-owl-2014/node_modules/
 
 # Add to the bottom of this list any files you wish to track.

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/npm-shrinkwrap.json
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/npm-shrinkwrap.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "jquery-knob": {
+      "version": "1.2.11",
+      "from": "git+https://github.com/valichek/jQuery-Knob.git",
+      "resolved": "git+https://github.com/valichek/jQuery-Knob.git#5c8cd1e74c38bcfd09b1d96e9e39bdabda5a3db5"
+    }
+  }
+}

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/package.json
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jquery-knob": "git+https://github.com/valichek/jQuery-Knob.git"
+  }
+}

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library.php
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library.php
@@ -21,7 +21,7 @@ wp_enqueue_style('jquery-ui-style-theme', get_template_directory_uri() . '/js/jq
 wp_enqueue_script('owl-patches-page_knockout',      $resUri . 'js3rdparty/knockout-2.0.0.js');
 wp_enqueue_script('jquery',                         $resUri . 'js3rdparty/jquery-1.7.1.min.js');
 wp_enqueue_script('jquery-ui',                      get_template_directory_uri() . '/js/jquery-ui-1.11.4.custom/jquery-ui.min.js', array('jquery'));
-wp_enqueue_script('owl-patches-page_jquery_knob',   $resUri . 'js3rdparty/jquery.knob.min.js', array('jquery'));
+wp_enqueue_script('owl-patches-page_jquery_knob',   get_template_directory_uri() . '/node_modules/jquery-knob/js/jquery.knob.js', array('jquery'));
 wp_enqueue_script('owl-patches-page_knob',          $resUri . 'js/knob.js');
 
 wp_enqueue_script('owl-patches-page_prettify',      'https://google-code-prettify.googlecode.com/svn/trunk/src/prettify.js');
@@ -222,23 +222,23 @@ wp_enqueue_script('pd-fileutils',                   $resUri . 'js3rdparty/pd-fil
                 </div>
                 <div class="flexbox flex-center patch-tab-container">
                     <div class="knob-container" id="patch-parameter-a">
-                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="false" data-fgColor="#ed7800" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
+                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="true" data-fgColor="#aaa" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
                         <p class="parameter-label" data-bind="text: parameters.a"></p>
                     </div>
                     <div class="knob-container" id="patch-parameter-b">
-                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="false" data-fgColor="#ed7800" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
+                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="true" data-fgColor="#aaa" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
                         <p class="parameter-label" data-bind="text: parameters.b"></p>
                     </div>
                     <div class="knob-container" id="patch-parameter-c">
-                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="false" data-fgColor="#ed7800" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
+                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="true" data-fgColor="#aaa" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
                         <p class="parameter-label" data-bind="text: parameters.c"></p>
                     </div>
                     <div class="knob-container" id="patch-parameter-d">
-                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="false" data-fgColor="#ed7800" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
+                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="true" data-fgColor="#aaa" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
                         <p class="parameter-label" data-bind="text: parameters.d"></p>
                     </div>
                     <div class="knob-container" id="patch-parameter-e">
-                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="false" data-fgColor="#ed7800" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
+                        <input class="knob" data-displayPreviousValue="true" data-angleOffset="-125" data-angleArc="250" data-displayInput="true" data-readOnly="true" data-fgColor="#aaa" data-linecap="round" data-width="100%" data-rotation="clockwise" value="35">
                         <p class="parameter-label" data-bind="text: parameters.e"></p>
                     </div>
                 </div>

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/knob.js
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/knob.js
@@ -4,14 +4,7 @@ function knobify () {
         HoxtonOwl.patchManager.updatePatchParameters();
     }
 
-    $(".knob.enabled").knob({
-        change : knobChange,
-        release : knobChange,
-    });
-
-    $(".knob.disabled").knob({
-        'readOnly': true,
-        'fgColor': '#aaa',
+    $(".knob").knob({
         change : knobChange,
         release : knobChange,
     });

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/patchManager.js
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/patchManager.js
@@ -566,6 +566,7 @@ HoxtonOwl.patchManager = {
 
                 var resetPatchParameterView = function () {
                     $('.knob').val(35).trigger('change');
+                    $('.knob-container:visible input.knob').css('visibility', 'hidden');
                 };
                 resetPatchParameterView();
 
@@ -595,6 +596,7 @@ HoxtonOwl.patchManager = {
                         $('#patch-tab-midi').hide();
                         $('#patch-tab-test').show();
                         $('.knob').val(35).trigger('change');
+                        $('.knob-container:visible input.knob').css('visibility', 'visible');
                         pm.initPatchTest();
                         changeKnobReadOnlyState(false);
                     } else if ('patch-tab-header-midi' === id) {

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/patchManager.js
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/patchManager.js
@@ -216,7 +216,7 @@ HoxtonOwl.patchManager = {
             $('#patch-tab-test-err-4').hide();
 
             $('#patch-test-inner-container').show();
-            $('.knob').val(50).trigger('change');
+            $('.knob').val(35).trigger('change');
             // $('#patch-test-source').select2({
             //     placeholder: 'Select a source',
             //     minimumResultsForSearch: Infinity

--- a/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/patchManager.js
+++ b/web/wordpress/wp-content/themes/hoxton-owl-2014/page-patch-library/js/patchManager.js
@@ -531,14 +531,15 @@ HoxtonOwl.patchManager = {
                         });
                     }
                 }
-
-                $('.knob').addClass('disabled');
+                
+                // add colour to knobs for which parameters exist in this patch
                 if (patch.parameters) {
                     for (var key in patch.parameters) {
-                        $('#patch-parameter-' + key + ' .knob').removeClass('disabled').addClass('enabled');
+                        console.log(key);
+                        $('#patch-parameter-' + key + ' .knob').attr('data-fgColor', '#ed7800');
                     }
                 }
-                knobify();
+                knobify();                
 
                 // Show build download links
                 if (that.selectedPatch().sysExAvailable) {
@@ -565,28 +566,17 @@ HoxtonOwl.patchManager = {
 
                 var resetPatchParameterView = function () {
                     $('.knob').val(35).trigger('change');
-                    $('.knob-container:visible input.knob').css('visibility', 'hidden');
-
-                    // This is a workaround to make the knobs unresponsive to mouse/touch events:
-                    $('.knob-container canvas:visible').each(function (i, el) {
-                        var rect = el.getBoundingClientRect();
-                        var css = {
-                            // 'background-color': 'red',
-                            // 'opacity':          0.3,
-                            'position': 'absolute',
-                            'top':      Math.round(rect.top + window.scrollY) + 'px',
-                            'left':     Math.round(rect.left + window.scrollX) + 'px',
-                            'width':    Math.round(rect.width) + 'px',
-                            'height':   Math.round(rect.height) + 'px'
-                        };
-                        var styles = '';
-                        for (rule in css) {
-                            styles += rule + ': ' + css[rule] + '; ';
-                        }
-                        $('body').append($('<div class="knob-disabler" style="' + styles + '"></div>'));
-                    });
                 };
                 resetPatchParameterView();
+
+                function changeKnobReadOnlyState(readonly) {
+                    if (patch.parameters) {
+                        for (var key in patch.parameters) {
+                            console.log(key);
+                            $('#patch-parameter-' + key + ' .knob').trigger('configure', {"readOnly":readonly});
+                        }
+                    }
+                }
 
                 $('.patch-tab-header a').click(function (e) {
                     var $tab = $(e.target).closest('h2'),
@@ -599,20 +589,21 @@ HoxtonOwl.patchManager = {
                         $('#patch-tab-info').show();
                         pm.stopPatchTest();
                         resetPatchParameterView();
+                        changeKnobReadOnlyState(true);
                     } else if ('patch-tab-header-test' === id) {
                         $('#patch-tab-info').hide();
                         $('#patch-tab-midi').hide();
                         $('#patch-tab-test').show();
                         $('.knob').val(35).trigger('change');
-                        $('.knob-container:visible input.knob').css('visibility', 'visible');
-                        $('.knob-disabler').remove();
                         pm.initPatchTest();
+                        changeKnobReadOnlyState(false);
                     } else if ('patch-tab-header-midi' === id) {
                         $('#patch-tab-info').hide();
                         $('#patch-tab-test').hide();
                         $('#patch-tab-midi').show();
                         pm.stopPatchTest();
                         resetPatchParameterView();
+                        changeKnobReadOnlyState(true);
                     }
                     return false;
                 });


### PR DESCRIPTION
With this branch, we begin using npm to manage js dependencies. This will make it easier for us to update to newer versions when they become available.

package.json defines the dependencies. npm-shrinkwrap.json keeps track of the specific version of the dependency we are currently using, right down to the commit. This will help us get back to a working setup if a future version breaks any functionality.

This branch removes the 'knob disabler' hidden divs, and instead updates the readOnly state of the knobs dynamically. We had to use a fork of jquery-knob to achieve this.