### PR TITLE
JavaScript build improvements

### DIFF
--- a/web/owlspa/package.json
+++ b/web/owlspa/package.json
@@ -7,7 +7,9 @@
     "test:prod": "karma start --single-run",
     "test:dev": "karma start",
     "buildprod": "NODE_ENV=production webpack -p --config webpack.prod.config.js",
-    "start": "webpack --config webpack.dev.config.js --watch"
+    "builddev": "webpack --config webpack.dev.config.js",
+    "start": "webpack --config webpack.dev.config.js --watch",
+    "webpack": "webpack"
   },
   "repository": {
     "type": "git",

--- a/web/owlspa/package.json
+++ b/web/owlspa/package.json
@@ -8,8 +8,7 @@
     "test:dev": "karma start",
     "buildprod": "NODE_ENV=production webpack -p --config webpack.prod.config.js",
     "builddev": "webpack --config webpack.dev.config.js",
-    "start": "webpack --config webpack.dev.config.js --watch",
-    "webpack": "webpack"
+    "start": "webpack --config webpack.dev.config.js --watch"
   },
   "repository": {
     "type": "git",

--- a/web/owlspa/src/containers/CreatePatchPage/CreatePatchPage.js
+++ b/web/owlspa/src/containers/CreatePatchPage/CreatePatchPage.js
@@ -211,7 +211,7 @@ class CreatePatchPage extends Component {
                     </div>
                   </div>
                   <div className="info-message" style={{marginBottom: '15px'}}>
-                    Supported File Types:  .c  .h  .cpp  .hpp  .pd  .dsp  .s .cc .maxpat .maxproj .gendsp
+                    Supported File Types:  .c  .h  .cpp  .hpp  .pd  .dsp  .s .cc .gendsp
                   </div>
                 </div>
 

--- a/web/wordpress/.gitignore
+++ b/web/wordpress/.gitignore
@@ -20,9 +20,10 @@
 !/wp-content/themes/hoxton-owl-2014/
 !/wp-content/themes/hoxton-owl-2014/**
 
-# Unfortunately, the above method reintroduces other 
+# Unfortunately, the above method reintroduces other
 # undesirable files, so we re-ignore them:
 .DS_Store
 /wp-content/themes/hoxton-owl-2014/node_modules/
+/wp-content/themes/hoxton-owl-2014/page-patch-library/js/bundle.js*
 
 # Add to the bottom of this list any files you wish to track.


### PR DESCRIPTION
* Convenience NPM script to build `bundle.js` without the watch functionality (useful at set-up time);
* Make git ignore files generated by webpack.