### PR TITLE
Taking Heavy API token out of version control.

### DIFF
--- a/web/scripts/patch-builder/_meta/settings.tpl.php
+++ b/web/scripts/patch-builder/_meta/settings.tpl.php
@@ -9,12 +9,6 @@ define('MONGO_USE_AUTH',   false);
 define('MONGO_USER',       '');
 define('MONGO_PASS',       '');
 define('MONGO_DATABASE',   'owl_staging');
-<<<<<<< HEAD
 define('MONGO_COLLECTION', 'patches');
 
 define('HEAVY_TOKEN',      'heavy_token');
-||||||| merged common ancestors
-define('MONGO_COLLECTION', 'patches');
-=======
-define('MONGO_COLLECTION', 'patches');
->>>>>>> dev

--- a/web/scripts/patch-builder/_meta/settings.tpl.php
+++ b/web/scripts/patch-builder/_meta/settings.tpl.php
@@ -10,3 +10,5 @@ define('MONGO_USER',       '');
 define('MONGO_PASS',       '');
 define('MONGO_DATABASE',   'owl_staging');
 define('MONGO_COLLECTION', 'patches');
+
+define('HEAVY_TOKEN',      'heavy_token');

--- a/web/scripts/patch-builder/patch-builder.php
+++ b/web/scripts/patch-builder/patch-builder.php
@@ -17,7 +17,6 @@ define('PATCH_SRC_DIR_PREFIX',   'owl-src-');
 define('PATCH_BUILD_DIR_PREFIX', 'owl-build-');
 define('OWL_SRC_DIR',            '/opt/OwlProgram.online/');
 define('COMPILE_TIMEOUT',        80); // time-out in seconds
-define('HEAVY_TOKEN',            'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJzdGFydERhdGUiOiAiMjAxNi0xMi0xNVQxNjozMTo1NS4yNTU2NjUiLCAibmFtZSI6ICJvd2wifQ==.M_2pvMyhPTrG6sTMzeb9WowhBSCbOQfVYWUlmXRiNms=');
 
 $stdout = fopen('php://stdout', 'w+');
 $stderr = fopen('php://stderr', 'w+');


### PR DESCRIPTION
Taking Heavy API token out of version control.

***IMPORTANT:*** After merging this PR, you'll need to updated your `web/scripts/patch-builder/settings.php` file (take a look at `_meta/settings.tpl.php` to see how.

This also needs to be done in staging and production environment.