### PR TITLE
Fixes bug caused by wrong WP XML-RPC endpoint

### DIFF
--- a/web/api/lib/config.js
+++ b/web/api/lib/config.js
@@ -10,7 +10,7 @@ const joi = require('joi');
   'JWT_SECRET',
   'API_KEY',
   'PATCH_UPLOAD_SECRET',
-  'WORDPRESS_HOSTNAME',
+  'WORDPRESS_BASE_URL',
   'WORDPRESS_XML_RPC_USERNAME',
   'WORDPRESS_XML_RPC_PASSWORD',
   'PATCH_SOURCE_URL_FRAGMENT',
@@ -36,7 +36,7 @@ const config = {
     collection: process.env.MONGO_COLLECTION,
   },
   wordpress: {
-    hostname: process.env.WORDPRESS_HOSTNAME,
+    baseUrl: process.env.WORDPRESS_BASE_URL,
     patchUploadSecret: process.env.PATCH_UPLOAD_SECRET,
     xmlRpc: {
       username: process.env.WORDPRESS_XML_RPC_USERNAME,
@@ -64,7 +64,7 @@ const configSchema = joi.object().keys({
     collection: joi.string().required(),
   }),
   wordpress: joi.object().keys({
-    hostname: joi.string().required(),
+    baseUrl: joi.string().required(),
     patchUploadSecret: joi.string().required(),
     xmlRpc: joi.object().keys({
       username: joi.string().required(),

--- a/web/api/lib/wordpress-bridge.js
+++ b/web/api/lib/wordpress-bridge.js
@@ -6,7 +6,7 @@ const request = require('request');
 const config = require('./config');
 
 const client = wordpress.createClient({
-  url: config.wordpress.hostname,
+  url: config.wordpress.baseUrl,
   username: config.wordpress.xmlRpc.username,
   password: config.wordpress.xmlRpc.password,
 });
@@ -82,7 +82,7 @@ const getUserInfoBatch = userIds => {
 const uploadSources = (patchId, files) => {
 
   const requestOptions = {
-    url: `https://${config.wordpress.hostname}/wp-admin/admin-ajax.php`,
+    url: `${config.wordpress.baseUrl}/wp-admin/admin-ajax.php`,
     rejectUnauthorized: config.env === 'production', // if `false`, will allow self-signed SSL certificates
     formData: {
       patchId: patchId,

--- a/web/api/routes/patch.js
+++ b/web/api/routes/patch.js
@@ -393,7 +393,7 @@ router.post('/:id/sources', (req, res) => {
       const sourceUrls = successfulUploads.map(uploadedFile => {
         // Example:
         // https://staging.hoxtonowl.com/wp-content/uploads/patch-files/563b9a3031062254525b5831/TestTonePatch.hpp
-        return `https://${config.wordpress.hostname}/${config.wordpress.patchSourceUrlFragment}/${id}/${uploadedFile}`;
+        return `${config.wordpress.baseUrl}/${config.wordpress.patchSourceUrlFragment}/${id}/${uploadedFile}`;
       });
       return patchModel.addSources(id, sourceUrls);
     })

--- a/web/api/routes/patches.js
+++ b/web/api/routes/patches.js
@@ -101,7 +101,7 @@ router.post('/', (req, res) => {
         message: 'New patch saved.',
         _id: patch._id,
         seoName: patch.seoName,
-        url: `https://${config.wordpress.hostname}/patch-library/patch/${patch.seoName}`,
+        url: `${config.wordpress.baseUrl}/patch-library/patch/${patch.seoName}`,
         success: true,
       });
     })


### PR DESCRIPTION
Addressing a bug that made believe the API that the URL of the website was https://https://hoxtonowl.com

**Action required**
The environment variable `WORDPRESS_HOSTNAME` has been renamed to `WORDPRESS_BASE_URL`. You should update the file `web/api/.env` to reflect this.

Before:
```
# WordPress hostname
WORDPRESS_BASE_URL="https://hoxtonowl.com"
```

After

```
# Website base URL
WORDPRESS_HOSTNAME="https://hoxtonowl.com"
```