### PR TITLE
Adding in example of .env file

### DIFF
--- a/web/api/example.env
+++ b/web/api/example.env
@@ -1,0 +1,59 @@
+# NODE_ENV can either be `staging` or `production`
+NODE_ENV="production"
+
+# HTTP port on which the API will be listening
+API_PORT=3000
+
+#####################
+# Database settings #
+#####################
+
+# MONGO_CONNECTION_STRING is documented @ https://docs.mongodb.com/manual/reference/connection-string/
+MONGO_CONNECTION_STRING="mongodb://localhost:27017/owl_staging"
+
+# Collection to use
+MONGO_COLLECTION="patches"
+
+###########
+# Secrets #
+###########
+
+# `JWT_SECRET`, `API_KEY` and `PATCH_UPLOAD_SECRET` should be large, high quality
+# random numbers. A quick way to generate them is:
+#    $ node -e "console.log(require('crypto').randomBytes(32).toString('base64'));"
+
+# Secret used to sign JWT tokens
+JWT_SECRET="secret"
+
+# API key. Give this to authorized users.
+API_KEY="mystery"
+
+# This should be identical to the secret in `web/wordpress/wp-content/plugins/owl-patch-uploader-secret.php`
+PATCH_UPLOAD_SECRET="enigma"
+
+#############
+# WordPress #
+#############
+
+# WordPress base URL
+WORDPRESS_BASE_URL="https://staging.hoxtonowl.com"
+
+# WordPress XML-RPC credentials
+WORDPRESS_XML_RPC_USERNAME="owlapi"
+WORDPRESS_XML_RPC_PASSWORD="conundrum"
+
+# Patch upload URL fragment (relative to WordPress root)
+PATCH_SOURCE_URL_FRAGMENT="wp-content/uploads/patch-files"
+
+#################
+# Patch builder #
+#################
+
+PATCH_BUILDER_PATH="/var/www/hoxtonowl.com/staging/patch-builder/patch-builder.php"
+
+# Where to place builds
+SYSEX_PATH="/var/www/hoxtonowl.com/staging/patch-builder/build"
+JS_PATH="/var/www/hoxtonowl.com/staging/patch-builder/build-js"
+
+# Set this to `min` to build minified JavaScript patches, or else to `js`
+JS_BUILD_TYPE="min"


### PR DESCRIPTION
Putting under version control an example of `.env` file (which is not).